### PR TITLE
Add Id to Create 

### DIFF
--- a/src/core/api-client/resources/apps.ts
+++ b/src/core/api-client/resources/apps.ts
@@ -15,16 +15,18 @@ export default class Apps {
    * @returns {Promise<ConnectApp>} Promise object that resolves to a ConnectApp object.
    */
   async create({
+    id,
     name,
     type,
   }: {
+    id?: string;
     name: string;
     type: AppType;
   }): Promise<ConnectApp> {
     const response = await this.client.call<ConnectApp>({
       endpoint: "apps",
       method: "POST",
-      body: { name, type },
+      body: { id, name, type },
     });
 
     return response;
@@ -35,9 +37,11 @@ export default class Apps {
    * @returns {Promise<ConnectApp>} Promise object that resolves to a ConnectApp object.
    */
   async findOrCreateByName({
+    id,
     name,
     type,
   }: {
+    id?: string;
     name: string;
     type: AppType;
   }): Promise<ConnectApp> {
@@ -51,6 +55,7 @@ export default class Apps {
 
       if (code === ApiClientErrors.NotFound) {
         app = await this.create({
+          id,
           name: name,
           type: type,
         });

--- a/src/core/publish-app.ts
+++ b/src/core/publish-app.ts
@@ -73,6 +73,7 @@ export default async function publishApp(
     const pathToTarball = path.join(process.cwd(), tarballName);
 
     platformApp = await client.apps.findOrCreateByName({
+      id: app.manifest.id as unknown as string, // TODO: Update SDK definition for AppManifest to make id a known potential field.
       name: app.manifest.name,
       type: app.type,
     });


### PR DESCRIPTION
We need to be able to define applications that already exist in our system. 

In order to do this we will need to be able to create an application id based on the id already in our system. 

This id will exist as an optional id property in package.json

We need to send this id property to webapi when we create a new application so it knows not to set the id to an arbitrary guid.